### PR TITLE
Ignore the generic tablet while parsing

### DIFF
--- a/crates/tabletdb-cli/src/main.rs
+++ b/crates/tabletdb-cli/src/main.rs
@@ -240,17 +240,18 @@ fn cmd_list_local() -> Result<()> {
         .trim()
         .to_string();
 
-        let info = TabletInfo::new_from_path(&file.path())?;
-        cache.tablets().filter(|t| *t == &info).for_each(|tablet| {
-            let lookup = tablet_lookup_key(tablet);
-            locals
-                .entry(lookup)
-                .and_modify(|t| t.nodes.push((file.path(), name.clone())))
-                .or_insert(LocalTablet {
-                    tablet: tablet.clone(),
-                    nodes: vec![(file.path(), name.clone())],
-                });
-        })
+        if let Ok(info) = TabletInfo::new_from_path(&file.path()) {
+            cache.tablets().filter(|t| *t == &info).for_each(|tablet| {
+                let lookup = tablet_lookup_key(tablet);
+                locals
+                    .entry(lookup)
+                    .and_modify(|t| t.nodes.push((file.path(), name.clone())))
+                    .or_insert(LocalTablet {
+                        tablet: tablet.clone(),
+                        nodes: vec![(file.path(), name.clone())],
+                    });
+            })
+        }
     }
 
     for local in locals.values() {

--- a/crates/tabletdb-cli/src/main.rs
+++ b/crates/tabletdb-cli/src/main.rs
@@ -59,12 +59,15 @@ fn cmd_list_tablets() -> Result<()> {
 
     for tablet in tablets {
         println!(
-            "- {{ bus: {:<11} vid: '0x{:04x}', pid: '0x{:04x}', name: '{}', uniq: '{}' }}",
+            "- {{ bus: {:<11} vid: '0x{:04x}', pid: '0x{:04x}', name: '{}'{} }}",
             format!("'{}',", tablet.bustype()),
             *tablet.vendor_id(),
             tablet.product_id(),
             tablet.name(),
-            tablet.firmware_version().unwrap_or("")
+            tablet
+                .firmware_version()
+                .map(|fw| format!(", uniq: '{fw}'"))
+                .unwrap_or("".into())
         );
     }
 

--- a/crates/tabletdb-cli/src/main.rs
+++ b/crates/tabletdb-cli/src/main.rs
@@ -122,7 +122,6 @@ fn cmd_info(path: Option<String>) -> Result<()> {
                     BusType::Bluetooth => "bluetooth",
                     BusType::Serial => "serial",
                     BusType::I2C => "i2c",
-                    BusType::Unknown { .. } => "unknown",
                 }
             );
             println!("  vid: \"0x{:04x}\"", tablet.vendor_id());

--- a/crates/tabletdb/src/lib.rs
+++ b/crates/tabletdb/src/lib.rs
@@ -752,7 +752,6 @@ impl TabletInfo {
     /// - `/sys/devices/.../input/input0` sysfs input paths
     pub fn new_from_path(path: &Path) -> Result<TabletInfo> {
         let sysfs = if path.starts_with("/dev/input")
-            && path.is_file()
             && path
                 .file_name()
                 .unwrap()

--- a/crates/tabletdb/src/lib.rs
+++ b/crates/tabletdb/src/lib.rs
@@ -834,7 +834,7 @@ impl TabletInfo {
     /// The tablet must match this name given by the vendor.
     ///
     /// <div class="warning">
-    /// This is almost never the name to use, <em>kernel_name</em> instead.
+    /// This is almost never the name to use, use <em>kernel_name</em> instead.
     /// </div>
     ///
     /// Many Huion, XP-Pen, etc. devices differ in the official name
@@ -1521,10 +1521,7 @@ impl ToolFeatures for Eraser {
     }
 }
 
-/// A stylus describes one tool available on a tablet.
-///
-/// Not all [Stylus] tools are physically styli-like, e.g. the Wacom Lens Cursor
-/// is a mouse-like device.
+/// A stylus describes one stylus-like tool available on a tablet.
 #[derive(Debug, Clone, PartialEq)]
 pub struct Stylus {
     idx: usize,
@@ -1568,7 +1565,7 @@ impl ToolFeatures for Stylus {
 }
 
 impl Stylus {
-    /// Returns true if one of the buttons on the stylus triggers
+    /// Returns true if one of the physical buttons on the stylus triggers
     /// eraser behaviour. See the
     /// [Windows Pen States](https://learn.microsoft.com/en-us/windows-hardware/design/component-guidelines/windows-pen-states)
     /// for details.

--- a/crates/tabletdb/src/parser.rs
+++ b/crates/tabletdb/src/parser.rs
@@ -204,15 +204,6 @@ impl TryFrom<&str> for DeviceMatch {
     type Error = ParserError;
 
     fn try_from(s: &str) -> Result<DeviceMatch> {
-        if s == "generic" {
-            return Ok(DeviceMatch {
-                bustype: BusType::Unknown { bustype: 0 },
-                vid: VendorId::from(0x00),
-                pid: ProductId::from(0x00),
-                name: Some(String::from("Generic")),
-                fw: None,
-            });
-        }
         let components: Vec<&str> = s.split("|").collect();
         if components.len() < 3 {
             return Err(parser_error!("DeviceMatch", s));
@@ -366,7 +357,7 @@ impl TabletFile {
 
         let device_matches: Vec<DeviceMatch> = device_match
             .split(";")
-            .filter(|s| !s.is_empty())
+            .filter(|s| !s.is_empty() && *s != "generic")
             .map(DeviceMatch::try_from)
             .collect::<Result<Vec<DeviceMatch>>>()?;
 


### PR DESCRIPTION
Unlike C, any Rust code will be relatively easy to create its own
generic tablet instead of having to rely on a libwacom-style fallback
option.
